### PR TITLE
add spreadsheet rename feature

### DIFF
--- a/server/routers/panel.ts
+++ b/server/routers/panel.ts
@@ -430,6 +430,26 @@ const panelRouter = router({
       return true;
     }),
 
+  updateSessionName: userProcedure
+    .input(
+      z.object({
+        session_id: z.string().uuid(),
+        name: z.string(),
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      const user_id = ctx.session.data.session?.user?.id || '';
+
+      const { error } = await ctx.supabase
+        .from('swarms_spreadsheet_sessions')
+        .update({ name: input.name })
+        .eq('id', input.session_id)
+        .eq('user_id', user_id);
+
+      if (error) throw error;
+      return true;
+    }),
+
   updateSessionMetrics: userProcedure
     .input(
       z.object({

--- a/types_db.ts
+++ b/types_db.ts
@@ -1573,6 +1573,7 @@ export type Database = {
           created_at: string | null
           current: boolean | null
           id: string
+          name: string | null       
           output: Json | null
           task: string | null
           tasks_executed: number | null
@@ -1585,6 +1586,7 @@ export type Database = {
           created_at?: string | null
           current?: boolean | null
           id?: string
+          name?: string | null     
           output?: Json | null
           task?: string | null
           tasks_executed?: number | null
@@ -1597,6 +1599,7 @@ export type Database = {
           created_at?: string | null
           current?: boolean | null
           id?: string
+          name?: string | null      
           output?: Json | null
           task?: string | null
           tasks_executed?: number | null


### PR DESCRIPTION
fixed : #159


This PR introduces a new feature that allows users to rename their spreadsheet sessions. The update includes modifications to the `types_db.ts` file to support the new `name` field in the `swarms_spreadsheet_sessions` table and adds an `updateSessionName` mutation for renaming sessions.

### Summary of Changes

1. **Database Schema Update**:
   - Added a new `name` field to the `Row`, `Insert`, and `Update` types within the `swarms_spreadsheet_sessions` table in `types_db.ts`.
   
2. **Mutation to Update Session Name**:
   - Created an `updateSessionName` mutation using `userProcedure` to handle renaming functionality.
   - Input schema for `updateSessionName` includes:
     - `session_id` (UUID): Unique identifier for the session to be renamed.
     - `name` (String): New name for the session.
   - Updates the `name` field in the `swarms_spreadsheet_sessions` table where `id` and `user_id` match the provided values.