### PR TITLE
Fix Duplicate Column in ./schema.sql

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -373,7 +373,6 @@ CREATE TABLE IF NOT EXISTS "public"."swarms_cloud_agents" (
     "agent" "text",
     "name" "text",
     "use_cases" "json",
-    "agent" "text",
     "status" "public"."user_agents_status",
     "tags" "text",
     "description" "text"


### PR DESCRIPTION
### Fix Duplicate Column in `schema.sql`

---

### Description

This pull request resolves a schema issue by removing a duplicate `agent` column from the `swarms_cloud_agents` table in the `schema.sql` file. This correction ensures the schema can be cleanly applied during database configuration in Supabase.

---

### What Was Changed

- Removed the duplicate `agent` column from the `swarms_cloud_agents` table.

---

### Benefits

- Allows for a clean database configuration in Supabase without schema-related errors.
- Ensures the `swarms_cloud_agents` table is correctly defined.

---

### Testing

- Verified the updated `schema.sql` initializes without errors in Supabase.
- Confirmed the `swarms_cloud_agents` table functions as expected after the fix.

---

Please review and merge this correction. Thank you!
