### PR TITLE
fix: Remove duplicate "agent" column in swarms_cloud_agents schema

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -373,7 +373,6 @@ CREATE TABLE IF NOT EXISTS "public"."swarms_cloud_agents" (
     "agent" "text",
     "name" "text",
     "use_cases" "json",
-    "agent" "text",
     "status" "public"."user_agents_status",
     "tags" "text",
     "description" "text"


### PR DESCRIPTION
## Description
Fixed an issue in schema.sql where the "agent" column was defined twice in the swarms_cloud_agents table, causing a Postgres error (42701) during database initialization.

## Solution
Removed the duplicate "agent" column definition from the swarms_cloud_agents table schema.

## Screenshots
<img width="890" alt="image" src="https://github.com/user-attachments/assets/8f8e672f-3ebd-48f9-9b76-bff6219206bf" />
